### PR TITLE
Radix testing reencode

### DIFF
--- a/src/order-lazy.h
+++ b/src/order-lazy.h
@@ -136,4 +136,46 @@ int* lazy_order_initialize(struct lazy_int* p_lazy_o) {
 }
 
 // -----------------------------------------------------------------------------
+
+struct lazy_chr {
+  SEXP data;
+  const SEXP* p_data;
+  PROTECT_INDEX data_pi;
+
+  R_xlen_t size;
+  bool initialized;
+};
+
+#define PROTECT_LAZY_CHR(p_info, p_n) do {                \
+  PROTECT_WITH_INDEX((p_info)->data, &(p_info)->data_pi); \
+  *(p_n) += 1;                                            \
+} while (0)
+
+static inline
+struct lazy_chr new_lazy_chr(R_xlen_t size) {
+  return (struct lazy_chr) {
+    .data = R_NilValue,
+    .size = size,
+    .initialized = false
+  };
+}
+
+static inline
+const SEXP* lazy_chr_initialize(struct lazy_chr* p_x) {
+  if (p_x->initialized) {
+    return p_x->p_data;
+  }
+
+  p_x->data = Rf_allocVector(STRSXP, p_x->size);
+
+  REPROTECT(p_x->data, p_x->data_pi);
+
+  p_x->p_data = STRING_PTR_RO(p_x->data);
+
+  p_x->initialized = true;
+
+  return p_x->p_data;
+}
+
+// -----------------------------------------------------------------------------
 #endif

--- a/src/utils.c
+++ b/src/utils.c
@@ -386,6 +386,35 @@ SEXP p_chr_resize(const SEXP* p_x, R_xlen_t x_size, R_xlen_t size) {
   return out;
 }
 
+// [[ include("utils.h") ]]
+bool p_chr_any_reencode(const SEXP* p_x, R_xlen_t size) {
+  for (R_xlen_t i = 0; i < size; ++i) {
+    SEXP elt = p_x[i];
+
+    if (CHAR_NEEDS_REENCODE(elt)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+// [[ include("utils.h") ]]
+void p_chr_copy_with_reencode(const SEXP* p_x, SEXP x_result, R_xlen_t size) {
+  const void* vmax = vmaxget();
+
+  for (R_xlen_t i = 0; i < size; ++i) {
+    SEXP elt = p_x[i];
+
+    if (CHAR_NEEDS_REENCODE(elt)) {
+      SET_STRING_ELT(x_result, i, CHAR_REENCODE(elt));
+    } else {
+      SET_STRING_ELT(x_result, i, elt);
+    }
+  }
+
+  vmaxset(vmax);
+}
 
 inline void never_reached(const char* fn) {
   Rf_error("Internal error in `%s()`: Reached the unreachable.", fn);

--- a/src/utils.h
+++ b/src/utils.h
@@ -116,6 +116,9 @@ SEXP p_int_resize(const int* p_x, R_xlen_t x_size, R_xlen_t size);
 SEXP p_raw_resize(const Rbyte* p_x, R_xlen_t x_size, R_xlen_t size);
 SEXP p_chr_resize(const SEXP* p_x, R_xlen_t x_size, R_xlen_t size);
 
+bool p_chr_any_reencode(const SEXP* p_x, R_xlen_t size);
+void p_chr_copy_with_reencode(const SEXP* p_x, SEXP x_result, R_xlen_t size);
+
 SEXP vec_unique_names(SEXP x, bool quiet);
 SEXP vec_unique_colnames(SEXP x, bool quiet);
 


### PR DESCRIPTION
This PR adds a `lazy_chr` struct as a container for a re-encoded character vector.

I've determined that I was unsafely assigning to the pointer returned by `STRING_PTR()`, especially when re-encoding was required. `CHAR_REENCODE()` might generate a new CHARSXP, and I was assigning it straight into a character vector using the pointer. In light of the fact that `SET_STRING_ELT()` fixes up the old/new node generation stuff, it would be better to re-encode once and use `SET_STRING_ELT()` when assigning those newly re-encoded CHARSXPs. That is what this PR does. 

The lazy character vector `p_lazy_x_reencoded` is threaded all the way through, but is only allocated when we have a character vector that needs re-encoding. In that case, `p_chr_copy_with_reencode()` is called to copy over to the lazy character container, with re-encoding. It is here that we now safely assign with `SET_STRING_ELT()`.

This actually improves performance in the re-encoding case, because previously we were calling `CHAR_REENCODE()` twice, once when marking unique values, and once when copying re-encoded strings over into an auxiliary buffer. Now it only happens once.

This PR also tweaks `chr_sortedness()` to fix some potentially unsafe protection handling of CHARSXPs. This function calls `CHAR_REENCODE()`, but it wasn't protecting the result.