### PR TITLE
Cleanup TRUELENGTHs with `R_ExecWithCleanup()`

### DIFF
--- a/src/order.c
+++ b/src/order.c
@@ -2682,7 +2682,7 @@ void chr_order_chunk(bool decreasing,
 }
 
 
-struct chr_order_data_exec {
+struct chr_order_info {
   SEXP x;
   bool decreasing;
   bool na_last;
@@ -2698,7 +2698,7 @@ struct chr_order_data_exec {
   struct truelength_info* p_truelength_info;
 };
 
-struct chr_order_data_cleanup {
+struct chr_order_cleanup_info {
   struct truelength_info* p_truelength_info;
 };
 
@@ -2725,7 +2725,7 @@ void chr_order(SEXP x,
                struct group_infos* p_group_infos,
                struct lazy_chr* p_lazy_x_reencoded,
                struct truelength_info* p_truelength_info) {
-  struct chr_order_data_exec data_exec = {
+  struct chr_order_info info = {
     .x = x,
     .decreasing = decreasing,
     .na_last = na_last,
@@ -2741,15 +2741,15 @@ void chr_order(SEXP x,
     .p_truelength_info = p_truelength_info
   };
 
-  struct chr_order_data_cleanup data_cleanup = {
+  struct chr_order_cleanup_info cleanup_info = {
     .p_truelength_info = p_truelength_info
   };
 
   R_ExecWithCleanup(
     chr_order_exec,
-    &data_exec,
+    &info,
     chr_order_cleanup,
-    &data_cleanup
+    &cleanup_info
   );
 }
 
@@ -2769,22 +2769,22 @@ static void chr_order_internal(SEXP x,
 
 static
 SEXP chr_order_exec(void* p_data) {
-  struct chr_order_data_exec* p_data_exec = (struct chr_order_data_exec*) p_data;
+  struct chr_order_info* p_info = (struct chr_order_info*) p_data;
 
   chr_order_internal(
-    p_data_exec->x,
-    p_data_exec->decreasing,
-    p_data_exec->na_last,
-    p_data_exec->size,
-    p_data_exec->p_lazy_o,
-    p_data_exec->p_lazy_x_chunk,
-    p_data_exec->p_lazy_x_aux,
-    p_data_exec->p_lazy_o_aux,
-    p_data_exec->p_lazy_bytes,
-    p_data_exec->p_lazy_counts,
-    p_data_exec->p_group_infos,
-    p_data_exec->p_lazy_x_reencoded,
-    p_data_exec->p_truelength_info
+    p_info->x,
+    p_info->decreasing,
+    p_info->na_last,
+    p_info->size,
+    p_info->p_lazy_o,
+    p_info->p_lazy_x_chunk,
+    p_info->p_lazy_x_aux,
+    p_info->p_lazy_o_aux,
+    p_info->p_lazy_bytes,
+    p_info->p_lazy_counts,
+    p_info->p_group_infos,
+    p_info->p_lazy_x_reencoded,
+    p_info->p_truelength_info
   );
 
   return R_NilValue;
@@ -2792,8 +2792,8 @@ SEXP chr_order_exec(void* p_data) {
 
 static
 void chr_order_cleanup(void* p_data) {
-  struct chr_order_data_cleanup* p_data_cleanup = (struct chr_order_data_cleanup*) p_data;
-  truelength_reset(p_data_cleanup->p_truelength_info);
+  struct chr_order_cleanup_info* p_info = (struct chr_order_cleanup_info*) p_data;
+  truelength_reset(p_info->p_truelength_info);
 }
 
 static
@@ -3335,7 +3335,7 @@ bool chr_str_ge(SEXP x, SEXP y, int x_size, const R_len_t pass) {
 
 // -----------------------------------------------------------------------------
 
-struct df_order_data_exec {
+struct df_order_info {
   SEXP x;
   SEXP decreasing;
   SEXP na_last;
@@ -3351,7 +3351,7 @@ struct df_order_data_exec {
   struct truelength_info* p_truelength_info;
 };
 
-struct df_order_data_cleanup {
+struct df_order_cleanup_info {
   struct truelength_info* p_truelength_info;
 };
 
@@ -3390,7 +3390,7 @@ void df_order(SEXP x,
               struct group_infos* p_group_infos,
               struct lazy_chr* p_lazy_x_reencoded,
               struct truelength_info* p_truelength_info) {
-  struct df_order_data_exec data_exec = {
+  struct df_order_info info = {
     .x = x,
     .decreasing = decreasing,
     .na_last = na_last,
@@ -3406,15 +3406,15 @@ void df_order(SEXP x,
     .p_truelength_info = p_truelength_info
   };
 
-  struct df_order_data_cleanup data_cleanup = {
+  struct df_order_cleanup_info cleanup_info = {
     .p_truelength_info = p_truelength_info
   };
 
   R_ExecWithCleanup(
     df_order_exec,
-    &data_exec,
+    &info,
     df_order_cleanup,
-    &data_cleanup
+    &cleanup_info
   );
 }
 
@@ -3434,22 +3434,22 @@ static void df_order_internal(SEXP x,
 
 static
 SEXP df_order_exec(void* p_data) {
-  struct df_order_data_exec* p_data_exec = (struct df_order_data_exec*) p_data;
+  struct df_order_info* p_info = (struct df_order_info*) p_data;
 
   df_order_internal(
-    p_data_exec->x,
-    p_data_exec->decreasing,
-    p_data_exec->na_last,
-    p_data_exec->size,
-    p_data_exec->p_lazy_o,
-    p_data_exec->p_lazy_x_chunk,
-    p_data_exec->p_lazy_x_aux,
-    p_data_exec->p_lazy_o_aux,
-    p_data_exec->p_lazy_bytes,
-    p_data_exec->p_lazy_counts,
-    p_data_exec->p_group_infos,
-    p_data_exec->p_lazy_x_reencoded,
-    p_data_exec->p_truelength_info
+    p_info->x,
+    p_info->decreasing,
+    p_info->na_last,
+    p_info->size,
+    p_info->p_lazy_o,
+    p_info->p_lazy_x_chunk,
+    p_info->p_lazy_x_aux,
+    p_info->p_lazy_o_aux,
+    p_info->p_lazy_bytes,
+    p_info->p_lazy_counts,
+    p_info->p_group_infos,
+    p_info->p_lazy_x_reencoded,
+    p_info->p_truelength_info
   );
 
   return R_NilValue;
@@ -3457,8 +3457,8 @@ SEXP df_order_exec(void* p_data) {
 
 static
 void df_order_cleanup(void* p_data) {
-  struct df_order_data_cleanup* p_data_cleanup = (struct df_order_data_cleanup*) p_data;
-  truelength_reset(p_data_cleanup->p_truelength_info);
+  struct df_order_cleanup_info* p_info = (struct df_order_cleanup_info*) p_data;
+  truelength_reset(p_info->p_truelength_info);
 }
 
 


### PR DESCRIPTION
This PR uses `R_ExecWithCleanup()` in two places to more safely reset truelengths of CHARSXPs.

`chr_order()` is used to process either a single character vector or the first column of a data frame if it is a character vector. I've now wrapped the implementation of this function in `R_ExecWithCleanup()`, and the cleanup function calls `truelength_reset()`. If we are ordering a character vector and a longjump occurs (due to allocation failure or an internal error), this ensures that the truelengths get reset on exit.

For `df_order()`, when a character column is encountered we normally mark the truelengths of the entire column, process the chunks, and then reset the entire column before moving on to the next column. It is possible that a longjump could occur while processing the chunks. The easiest thing to do here was to wrap all of `df_order()` in `R_ExecWithCleanup()`. The cleanup function again calls `truelength_reset()`. When there are no character columns, this is essentially a no-op. When there are character columns in the data frame, but their truelengths got reset properly, this is again a no-op. It really only does something if we are in the middle of processing a character column and a longjump occurs.